### PR TITLE
Toggle the I bit each login attempt so we send Login and Login (retry).

### DIFF
--- a/src/iscsi.c
+++ b/src/iscsi.c
@@ -1676,7 +1676,7 @@ isboot_do_login(struct isboot_sess *sess)
 {
 	pdu_t pdu, *pp;
 	uint8_t *req;
-	int I_bit;
+	static int I_bit = 1;
 	int T_bit, C_bit;
 	int CSG, NSG;
 	int error;
@@ -1709,7 +1709,10 @@ next_loginpdu:
 	req = (uint8_t *)&pdu.ipdu.bhs;
 	memset(req, 0, ISCSI_BHS_LEN);
 	req[0] = ISCSI_OP_LOGIN_REQ;
-	I_bit = 1;
+	/* Flip I bit each time as a cheap way to toggle between Login
+	 * and Login (retry). Some targets (eg ctld) do not handle
+	 * the later */
+	I_bit ^= 1;
 	T_bit = C_bit = 0;
 	CSG = NSG = 0;
 	BDADD8(&req[0], I_bit, 7);


### PR DESCRIPTION
ctld (and possibily others) only accept the former.
From https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=227313
