### PR TITLE
Fix early free of ITT when seperate status

### DIFF
--- a/src/iscsi.c
+++ b/src/iscsi.c
@@ -2864,7 +2864,7 @@ isboot_rsp_read_data(struct isboot_sess *sess, pdu_t *pp)
 		xpt_done(ccb);
 		mtx_unlock(&sess->cam_mtx);
 	}
-	if (F_bit) {
+	if (F_bit & S_bit) {
 		mtx_lock(&sess->task_mtx);
 		ISBOOT_TRACE("remove ccb ITT=%x\n", taskp->ITT);
 		TAILQ_REMOVE(&sess->taskq, taskp, tasks);


### PR DESCRIPTION
If the Mode Sense request fails for this particular LUN, the error status can arrive in a seperate PDU after the initial data response, expecting the same ITT.

Conforms to RFC3720 10.7.3. Tested on tgtd v1.0.81, where the default lun0 responds with such an error.